### PR TITLE
👷 (packages) 🌃️ nightly cron job ⏲️ semantic-release timing

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,20 +1,15 @@
-name: '🚀️ Semantic Release'
+name: '🌃️ Nightly Build(s)'
 on:
-  pull_request:
-    branches:
-      - main
-      - canary
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # ref: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#schedule
+    - cron: '0 0 * * *'
   push:
     branches:
-      - main
-      - canary
-      - ci/**
-      - feature/**
-      - fix/**
-      - release/**
+      - ci/cron-staged
 jobs:
   release:
-    name: '🚀️ Semantic Release'
+    name: '🌃️ Nightly Build(s)'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -37,19 +32,13 @@ jobs:
       - name: '📦️ Install Dependecies'
         run: |
           yarn install --frozen-lockfile --ignore-engines --network-concurrency 1
-      - name: '🚨️  Lint'
+      - name: '🏗️ Build Step'
         run: |
           yarn lint
-      - name: '⚗️  Test'
-        run: |
           yarn test
-      - name: '🏗️  Build via [build]'
-        if: !endsWith(github.event.head_commit.message , '[build]')
-        run: |
           yarn build
           yarn build:binaries
-      - name: '🏷️  Semantic Release via [build]'
-        if: !endsWith(github.event.head_commit.message , '[build]')
+      - name: '🏷️ Semantic Version: Release'
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,9 +4,6 @@ on:
     # * is a special character in YAML so you have to quote this string
     # ref: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#schedule
     - cron: '0 0 * * *'
-  push:
-    branches:
-      - ci/cron-staged
 jobs:
   release:
     name: '🌃️ Nightly Build(s)'

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -1,12 +1,12 @@
-name: '🌃️  Nightly'
+name: '⚗️ Pull Request'
 on:
-  schedule:
-    # * is a special character in YAML so you have to quote this string
-    # ref: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#schedule
-    - cron: '0 0 * * *'
+  pull_request:
+    branches:
+      - main
+      - canary
 jobs:
   release:
-    name: '🌃️  Nightly'
+    name: '⚗️ Pull Request'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -35,17 +35,3 @@ jobs:
       - name: '⚗️  Test'
         run: |
           yarn test
-      - name: '🏗️  Build'
-        run: |
-          yarn build
-          yarn build:binaries
-      - name: '🏷️  Semantic Release'
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          echo "registry=http://registry.npmjs.org/" >> .npmrc
-          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
-          echo "@jeromefitz:registry=https://registry.npmjs.org/" >> .npmrc
-          yarn semantic-release

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -40,12 +40,12 @@ jobs:
         run: |
           yarn test
       - name: '🏗️  Build'
-        if: endsWith(github.event.head_commit.message , '[build]')
+        if: contains(github.event.head_commit.message , '[build]')
         run: |
           yarn build
           yarn build:binaries
       - name: '🏷️  Semantic Release'
-        if: endsWith(github.event.head_commit.message , '[build]')
+        if: contains(github.event.head_commit.message , '[build]')
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,9 +1,5 @@
-name: '🚀️ Semantic Release'
+name: '🔀️ Push'
 on:
-  pull_request:
-    branches:
-      - main
-      - canary
   push:
     branches:
       - main
@@ -14,7 +10,7 @@ on:
       - release/**
 jobs:
   release:
-    name: '🚀️ Semantic Release'
+    name: '🔀️ Push'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -43,12 +43,12 @@ jobs:
       - name: '⚗️  Test'
         run: |
           yarn test
-      - name: '🏗️  Build via [build]'
+      - name: '🏗️  Build'
         if: !endsWith(github.event.head_commit.message , '[build]')
         run: |
           yarn build
           yarn build:binaries
-      - name: '🏷️  Semantic Release via [build]'
+      - name: '🏷️  Semantic Release'
         if: !endsWith(github.event.head_commit.message , '[build]')
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -44,12 +44,12 @@ jobs:
         run: |
           yarn test
       - name: '🏗️  Build'
-        if: !endsWith(github.event.head_commit.message , '[build]')
+        if: endsWith(github.event.head_commit.message , '[build]')
         run: |
           yarn build
           yarn build:binaries
       - name: '🏷️  Semantic Release'
-        if: !endsWith(github.event.head_commit.message , '[build]')
+        if: endsWith(github.event.head_commit.message , '[build]')
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -11,3 +11,9 @@ I would say use at your own risk, and if we ever need to promote one of these ou
 - :octocat: `actions` for release management through npm
 - 🤖️ Depandabot for Patch + Minor Package Management
 - 🤖️ Kodiak for Automerge of PRs via Labels and Rebasing
+
+## CI Testing
+
+- 🌃️ Nightly: Run `semantic-release` on `main` for any merges that took place
+- ⚗️ Pull Request: Run `lint` on any PR
+- 🔀️ Push: Extra check if last line of subject of commit is `[build]` to trigger `semantic-release` manually

--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ I would say use at your own risk, and if we ever need to promote one of these ou
 
 ## CI Testing
 
-- 🌃️ Nightly: Run `semantic-release` on `main` for any merges that took place
-- ⚗️ Pull Request: Run `lint` on any PR
-- 🔀️ Push: Extra check if last line of subject of commit is `[build]` to trigger `semantic-release` manually
+- 🌃️ **Nightly**: Run `semantic-release` on `main` for any merges that took place
+- ⚗️ **Pull Request**: Run `lint` on any PR
+- 🔀️ **Push**: Extra check if commit has `[build]` within its message to trigger `semantic-release` manually (still must meet requirements to create a build and have `semver` conventional commits)

--- a/packages/git-cz/src/utils/setBranch.ts
+++ b/packages/git-cz/src/utils/setBranch.ts
@@ -1,5 +1,5 @@
 import chalkPipe from 'chalk-pipe'
-import shellsync from 'shellsync'
+// import shellsync from 'shellsync'
 
 import executeCommand from './executeCommand'
 
@@ -35,7 +35,7 @@ const setBranch = ({
     console.log(chalkPipe('white.italic')(command))
     console.log()
   } else {
-    executeCommand(shellsync`${command}`)
+    executeCommand(command)
   }
 }
 

--- a/packages/semantic/src/branches.js
+++ b/packages/semantic/src/branches.js
@@ -1,8 +1,8 @@
 const _map = require('lodash/map')
 
 const releaseBranchTypes = {
-  ci: [],
-  feature: ['git-cz'],
+  ci: ['cron-staged'],
+  feature: [],
   fix: [],
   // @note this is "sprint"
   release: [],

--- a/packages/semantic/src/branches.js
+++ b/packages/semantic/src/branches.js
@@ -1,7 +1,7 @@
 const _map = require('lodash/map')
 
 const releaseBranchTypes = {
-  ci: ['cron-staged'],
+  ci: [],
   feature: [],
   fix: [],
   // @note this is "sprint"


### PR DESCRIPTION
## CI Testing

- 🌃️ **Nightly**: Run `semantic-release` on `main` for any merges that took place
- ⚗️ **Pull Request**: Run `lint` on any PR
- 🔀️ **Push**: Extra check if commit has `[b_u_i_l_d]` (w/o the `_` need to ensure we do not `b_u_i_l_d` on PR merge and test the nightly) within its message to trigger `semantic-release` manually (still must meet requirements to create a `b_u_i_l_d` and have `semver` conventional commits)