### PR TITLE
👷  (cache) improved w/ turbo fallback (✿◠‿◠)

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -1,4 +1,4 @@
-name: '⚗️ Pull Request'
+name: '▶️ Pull'
 on:
   pull_request:
     branches:
@@ -6,12 +6,19 @@ on:
       # prerelease
       - canary
       - develop
-# concurrency:
-#   group: pull-${{ github.ref }}-1
-#   cancel-in-progress: true
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - converted_to_draft
+concurrency:
+  group: pull-${{ github.ref }}-1
+  cancel-in-progress: true
 jobs:
   release:
-    name: '⚗️ Pull Request'
+    name: '👷️  Pull'
+    if: github.event.pull_request.draft == false
     timeout-minutes: 5
     runs-on: ubuntu-latest
     env:
@@ -26,14 +33,15 @@ jobs:
         node: ['16']
 
     steps:
-      - name: '🐙️  Git Checkout'
+      - name: '🐙️  Checkout'
         uses: actions/checkout@v2
         with:
-          # Number of commits to fetch.
-          # 0 indicates all history for all branches and tags.
-          fetch-depth: 10
+          # Number of commits to fetch. 0 indicates all history for all branches and tags.
+          # Default: 1
+          fetch-depth: 1
 
-      - name: '🛠️ Setup Node: ${{ matrix.node }}'
+      - name: '💽️  Node (${{ matrix.node }})'
+        id: node-setup
         uses: actions/setup-node@v2
         with:
           # architecture: 'x64'
@@ -41,34 +49,40 @@ jobs:
           cache: 'yarn'
           node-version: ${{ matrix.node }}
 
-      - name: '🌵️  Cache (yarn)'
-        id: cache-yarn
-        uses: actions/cache@v2
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            **/node_modules
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+      # - name: '🧶️  Cache (yarn)'
+      #   id: cache-yarn
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: |
+      #       **/node_modules
+      #     key: modules-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+      #     restore-keys: |
+      #       modules-${{ runner.os }}-
 
-      - name: '📦️ Install Dependecies'
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
+      - name: '📦️  Dependecies'
+        id: dependecies
         run: |
           yarn install --frozen-lockfile --ignore-engines --network-concurrency 1
 
-      - name: '🌵️  Cache (turbo)'
+      - name: '🔺️  Cache (turbo)'
         id: cache-turbo
         uses: actions/cache@v2
         with:
           path: .cache-turbo
-          key: turbo-1-${{ github.job }}-${{ github.ref_name }}-${{ github.sha }}
+          key: turbo-${{ github.job }}-${{ github.ref_name }}-${{ github.sha }}
+          # order of preference => turbo will re-check
           restore-keys: |
-            turbo-1-${{ github.job }}-${{ github.ref_name }}-
-            turbo-1-${{ github.job }}-
+            turbo-${{ github.job }}-${{ github.ref_name }}-
+            turbo-${{ github.job }}-
+            turbo-
 
       - name: '🚨️  Lint'
+        id: lint
         run: |
           yarn lint --cache-dir=".cache-turbo"
 
-      - name: '⚗️  Test'
+      - name: '🧪️  Test'
+        id: test
+        # @note(ci) comment out right now as this requires `build`
         run: |
           echo # yarn test --cache-dir=".cache-turbo"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   release:
-    name: '🔀️ Push'
+    name: '👷️  Push'
     timeout-minutes: 5
     runs-on: ubuntu-latest
     env:
@@ -31,14 +31,15 @@ jobs:
         node: ['16']
 
     steps:
-      - name: '🐙️  Git Checkout'
+      - name: '🐙️  Checkout'
         uses: actions/checkout@v2
         with:
-          # Number of commits to fetch.
-          # 0 indicates all history for all branches and tags.
-          fetch-depth: 10
+          # Number of commits to fetch. 0 indicates all history for all branches and tags.
+          # Default: 1
+          fetch-depth: 1
 
-      - name: '🛠️ Setup Node: ${{ matrix.node }}'
+      - name: '💽️  Node (${{ matrix.node }})'
+        id: node-setup
         uses: actions/setup-node@v2
         with:
           # architecture: 'x64'
@@ -46,44 +47,52 @@ jobs:
           cache: 'yarn'
           node-version: ${{ matrix.node }}
 
-      - name: '🌵️  Cache (yarn)'
-        id: cache-yarn
-        uses: actions/cache@v2
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            **/node_modules
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+      # - name: '🧶️  Cache (yarn)'
+      #   id: cache-yarn
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: |
+      #       **/node_modules
+      #     key: modules-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+      #     restore-keys: |
+      #       modules-${{ runner.os }}-
 
-      - name: '📦️ Install Dependecies'
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
+      - name: '📦️  Dependecies'
+        id: dependecies
         run: |
           yarn install --frozen-lockfile --ignore-engines --network-concurrency 1
 
-      - name: '🌵️  Cache (turbo)'
+      - name: '🔺️  Cache (turbo)'
         id: cache-turbo
         uses: actions/cache@v2
         with:
           path: .cache-turbo
-          key: turbo-1-${{ github.job }}-${{ github.ref_name }}-${{ github.sha }}
+          key: turbo-${{ github.job }}-${{ github.ref_name }}-${{ github.sha }}
+          # order of preference => turbo will re-check
           restore-keys: |
-            turbo-1-${{ github.job }}-${{ github.ref_name }}-
-            turbo-1-${{ github.job }}-
+            turbo-${{ github.job }}-${{ github.ref_name }}-
+            turbo-${{ github.job }}-
+            turbo-
 
       - name: '🚨️  Lint'
+        id: lint
         run: |
           yarn lint --cache-dir=".cache-turbo"
 
-      - name: '⚗️  Test'
+      - name: '🧪️  Test'
+        id: test
+        # @note(ci) comment out right now as this requires `build`
         run: |
           echo # yarn test --cache-dir=".cache-turbo"
 
       - name: '🏗️  Build'
+        id: build
         if: contains(github.event.head_commit.message , '[build]') || contains(github.event.head_commit.message , '[b]')
         run: |
           yarn build --cache-dir=".cache-turbo"
 
-      - name: '🏷️  Semantic Release'
+      - name: '🚀️  Release'
+        id: release
         if: contains(github.event.head_commit.message , '[build]') || contains(github.event.head_commit.message , '[b]')
         run: |
           echo "registry=http://registry.npmjs.org/" >> .npmrc

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,4 +1,4 @@
-name: '🌃️  Weekly'
+name: '🌃️ Weekly'
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
@@ -15,8 +15,8 @@ on:
     - cron: '0 0 * * 1'
 jobs:
   release:
-    name: '🌃️  Weekly'
-    timeout-minutes: 10
+    name: '👷️ Weekly'
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -30,14 +30,15 @@ jobs:
         node: ['16']
 
     steps:
-      - name: '🐙️  Git Checkout'
+      - name: '🐙️  Checkout'
         uses: actions/checkout@v2
         with:
-          # Number of commits to fetch.
-          # 0 indicates all history for all branches and tags.
-          fetch-depth: 10
+          # Number of commits to fetch. 0 indicates all history for all branches and tags.
+          # Default: 1
+          fetch-depth: 1
 
-      - name: '🛠️ Setup Node: ${{ matrix.node }}'
+      - name: '💽️  Node (${{ matrix.node }})'
+        id: node-setup
         uses: actions/setup-node@v2
         with:
           # architecture: 'x64'
@@ -45,44 +46,52 @@ jobs:
           cache: 'yarn'
           node-version: ${{ matrix.node }}
 
-      - name: '🌵️  Cache (yarn)'
-        id: cache-yarn
-        uses: actions/cache@v2
-        with:
-          path: |
-            ${{ steps.yarn-cache-dir-path.outputs.dir }}
-            **/node_modules
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+      # - name: '🧶️  Cache (yarn)'
+      #   id: cache-yarn
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: |
+      #       **/node_modules
+      #     key: modules-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+      #     restore-keys: |
+      #       modules-${{ runner.os }}-
 
-      - name: '📦️ Install Dependecies'
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
+      - name: '📦️  Dependecies'
+        id: dependecies
         run: |
           yarn install --frozen-lockfile --ignore-engines --network-concurrency 1
 
-      - name: '🌵️  Cache (turbo)'
+      - name: '🔺️  Cache (turbo)'
         id: cache-turbo
         uses: actions/cache@v2
         with:
           path: .cache-turbo
-          key: turbo-1-${{ github.job }}-${{ github.ref_name }}-${{ github.sha }}
+          key: turbo-${{ github.job }}-${{ github.ref_name }}-${{ github.sha }}
+          # order of preference => turbo will re-check
           restore-keys: |
-            turbo-1-${{ github.job }}-${{ github.ref_name }}-
-            turbo-1-${{ github.job }}-
+            turbo-${{ github.job }}-${{ github.ref_name }}-
+            turbo-${{ github.job }}-
+            turbo-
 
       - name: '🚨️  Lint'
+        id: lint
         run: |
           yarn lint --cache-dir=".cache-turbo"
 
-      - name: '⚗️  Test'
+      - name: '🧪️  Test'
+        id: test
+        # @note(ci) comment out right now as this requires `build`
         run: |
           echo # yarn test --cache-dir=".cache-turbo"
 
       - name: '🏗️  Build'
+        id: build
         # if: contains(github.event.head_commit.message , '[build]') || contains(github.event.head_commit.message , '[b]')
         run: |
           yarn build --cache-dir=".cache-turbo"
 
-      - name: '🏷️  Semantic Release'
+      - name: '🚀️  Release'
+        id: release
         # if: contains(github.event.head_commit.message , '[build]') || contains(github.event.head_commit.message , '[b]')
         run: |
           echo "registry=http://registry.npmjs.org/" >> .npmrc

--- a/changelog.config.js
+++ b/changelog.config.js
@@ -39,7 +39,7 @@ const commit = isOverride
         'branchFlag',
         'commitBreakingFlag',
         'commitBreaking',
-        'commitScopes',
+        // 'commitScopes',
         'commitTypes',
         'commitSubject',
         'commitBodyFlag',

--- a/packages/codestyle/package.json
+++ b/packages/codestyle/package.json
@@ -55,7 +55,7 @@
     "lint-staged": "12.2.2",
     "prettier": "2.5.1",
     "pretty-quick": "3.1.3",
-    "typescript": "4.5.4"
+    "typescript": "4.5.5"
   },
   "type": "module",
   "sideEffects": false,

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -85,7 +85,7 @@
     "react": "17.0.2",
     "react-bezier-curve-editor": "1.0.0",
     "react-dom": "17.0.2",
-    "typescript": "4.5.4"
+    "typescript": "4.5.5"
   },
   "peerDependencies": {
     "react": "17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9676,10 +9676,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@4.5.4:
-  version "4.5.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.4.tgz#a17d3a0263bf5c8723b9c52f43c5084edf13c2e8"
-  integrity sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==
+typescript@4.5.5:
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
+  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
 
 uglify-js@^3.1.4:
   version "3.14.5"


### PR DESCRIPTION
#### 📛️ naming
- Nothing real to report here, new naming, haha.

#### 🔑️ keys

#####  `cache-turbo`

fallback to latest `turbo-`, as `turbo` will do a double-check and with so many packages that won't be touched for each PR or PUSH we want to be cognizant of build times.

- `turbo-${{ github.job }}-${{ github.ref_name }}-${{ github.sha }}`
- `turbo-${{ github.job }}-${{ github.ref_name }}-`
- `turbo-${{ github.job }}-`
- `turbo-`

This has been tested in this PR, however, the real test for turbo caching will be:

- this pr goes to `main`
- new pr is created that only touches `1` package
- does `lint|build` happen for all?

#### 🔥️ `cache-yarn`

This is not necessary with the cache happening at `setup-node`
This _extra_ cache actually added more time with the  check and then yarn determining what it needs to do.
Removing it speeds things up

#### 📝️ todo

Eventual todo would be to utilize workflows so we do not have copy/paste everywhere. 🍝 