### PR TITLE
🩹 !bundle `conventional-gitmoji`, `tsup` pref [b]

### DIFF
--- a/changelog.config.js
+++ b/changelog.config.js
@@ -1,8 +1,9 @@
 import isCI from 'is-ci'
 
 if (!isCI) {
+  // @hack(dotenv) 14.3.0 breaking change
   const dotenv = await import('dotenv')
-  dotenv.config({ path: './.env' })
+  dotenv.default.config({ path: './.env' })
 }
 
 const isOverride = process.env.GIT_CZ__OVERRIDE_TEST

--- a/packages/conventional-gitmoji/package.json
+++ b/packages/conventional-gitmoji/package.json
@@ -21,8 +21,8 @@
   },
   "private": false,
   "scripts": {
-    "build": "tsup-node",
-    "dev": "tsup-node --watch",
+    "build": "tsup",
+    "dev": "tsup --watch",
     "---": "",
     "clean": "rm -rf .turbo && rm -rf dist",
     "clean:install": "yarn clean && rm -rf node_modules",

--- a/packages/conventional-gitmoji/tsup.config.ts
+++ b/packages/conventional-gitmoji/tsup.config.ts
@@ -1,12 +1,14 @@
 // import isCI from 'is-ci'
-import { defineConfig } from 'tsup'
+import { defineConfig, Options } from 'tsup'
 
 import { config as _config } from '../../tsup.config'
 
 const entry = ['src/**']
-const config = {
+const config: Options = {
   ..._config,
   entry,
+  external: [],
+  noExternal: ['gitmojis', 'title'],
 }
 
 export default defineConfig({

--- a/packages/git-cz/package.json
+++ b/packages/git-cz/package.json
@@ -32,8 +32,8 @@
   },
   "private": false,
   "scripts": {
-    "build": "tsup-node",
-    "dev": "tsup-node --watch",
+    "build": "tsup",
+    "dev": "tsup --watch",
     "---": "",
     "clean": "rm -rf .turbo && rm -rf dist",
     "clean:install": "yarn clean && rm -rf node_modules",
@@ -70,9 +70,6 @@
     "minimist": "1.2.5",
     "shellsync": "0.2.2",
     "word-wrap": "1.2.3"
-  },
-  "peerDependencies": {
-    "@jeromefitz/conventional-gitmoji": "^2.0.3"
   },
   "bin": {
     "git-cz": "./dist/cli.js",

--- a/packages/git-cz/tsup.config.ts
+++ b/packages/git-cz/tsup.config.ts
@@ -1,14 +1,14 @@
 // import isCI from 'is-ci'
-import { defineConfig } from 'tsup'
+import { defineConfig, Options } from 'tsup'
 
 import { config as _config } from '../../tsup.config'
 
 const entry = ['src/**']
-const config = {
+const config: Options = {
   ..._config,
   entry,
   external: [],
-  noExternal: ['@jeromefitz/conventional-gitmoji'],
+  noExternal: ['@jeromefitz/conventional-gitmoji', 'gitmojis'],
 }
 
 export default defineConfig({

--- a/packages/semantic/package.json
+++ b/packages/semantic/package.json
@@ -21,8 +21,8 @@
   },
   "private": false,
   "scripts": {
-    "build": "tsup-node",
-    "dev": "tsup-node --watch",
+    "build": "tsup",
+    "dev": "tsup --watch",
     "---": "",
     "clean": "rm -rf .turbo && rm -rf dist",
     "clean:install": "yarn clean && rm -rf node_modules",
@@ -53,9 +53,6 @@
     "semantic-release": "19.0.2",
     "semantic-release-commit-filter": "1.0.2",
     "title": "3.4.3"
-  },
-  "peerDependencies": {
-    "@jeromefitz/conventional-gitmoji": "^2.0.3"
   },
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
- 🩹 (git-cz) !bundle @jeromefitz/conventional-gitmoji
- 💽️ (dotenv) patch for 14.3.0
- 🩹 (semantic) !bundle @jeromefitz/conventional-gitmoji

`tsup-node` is always externalizing, switch to `tsup` for now for these packages.

Reference: 
- https://tsup.egoist.sh/#excluding-all-packages