### PR TITLE
🚨 eslint|tsconfig refactor (⏲️ reduce ~2.5m)

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,4 +1,24 @@
-module.exports = {
+const config = require('@jeromefitz/eslint-config/react.cjs')
+
+const overrides = [
+  {
+    ...config.overrides[0],
+    parserOptions: {
+      ...config.overrides[0].parserOptions,
+      tsconfigRootDir: __dirname,
+      project: [
+        './tsconfig.eslint.json',
+        './config/*/tsconfig.json',
+        './packages/*/tsconfig.json',
+      ],
+    },
+  },
+]
+
+const eslint = {
   extends: '@jeromefitz/eslint-config/react.cjs',
   root: true,
+  overrides,
 }
+
+module.exports = eslint

--- a/config/eslint-config/base.cjs
+++ b/config/eslint-config/base.cjs
@@ -7,10 +7,10 @@ module.exports = {
     node: true,
   },
   extends: ['prettier', 'plugin:import/errors', 'plugin:import/warnings'],
-  ignorePatterns: ['**/dist/*', '**/.next/*'],
+  ignorePatterns: ['**/.next/*', '**/dist/*', '**/node_modules/*'],
   parser: '@babel/eslint-parser',
   parserOptions: {
-    ecmaVersion: 2018,
+    ecmaVersion: 2022,
     sourceType: 'module',
     ecmaFeatures: {
       jsx: true,

--- a/config/eslint-config/typescript.cjs
+++ b/config/eslint-config/typescript.cjs
@@ -7,13 +7,13 @@ const eslintTypescript = {
       parser: '@typescript-eslint/parser',
       plugins: ['@typescript-eslint', 'import'],
       parserOptions: {
+        allowAutomaticSingleRunInference: true,
         ecmaFeatures: {
           jsx: true,
         },
-        ecmaVersion: 2018,
+        ecmaVersion: 2022,
         sourceType: 'module',
         project: ['./tsconfig.json'],
-        // typescript-eslint specific options
         warnOnUnsupportedTypeScriptVersion: true,
       },
       extends: [

--- a/packages/git-cz/src/utils/LimitedInputPrompt.js
+++ b/packages/git-cz/src/utils/LimitedInputPrompt.js
@@ -15,8 +15,10 @@ class LimitedInputPrompt extends InputPrompt {
 
     if (this.opt.leadingLabel) {
       if (typeof this.opt.leadingLabel === 'function') {
+        // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
         this.leadingLabel = ' ' + this.opt.leadingLabel(this.answers)
       } else {
+        // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
         this.leadingLabel = ' ' + this.opt.leadingLabel
       }
     } else {
@@ -68,6 +70,7 @@ class LimitedInputPrompt extends InputPrompt {
     } ${appendContent}`
 
     if (error) {
+      // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
       bottomContent = red('>> ') + error
     }
 

--- a/packages/utils/src/setCharAt/index.ts
+++ b/packages/utils/src/setCharAt/index.ts
@@ -1,5 +1,6 @@
 function setCharAt(str: string, index: number, chr: string) {
   if (index > str.length - 1) return str
+  // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
   return str.substring(0, index) + chr + str.substring(index + 1)
 }
 

--- a/packages/utils/src/stringToUUID/index.ts
+++ b/packages/utils/src/stringToUUID/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/restrict-plus-operands */
 /**
  * @note This is pretty hacky to say the least 🤣️
  */

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["./**/**/src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "noImplicitAny": false
+    "noImplicitAny": false,
+    "noEmit": true
   },
   "extends": "@jeromefitz/tsconfig/node14.json",
   "exclude": []


### PR DESCRIPTION
- 🚨 refactor tsconfig top-level
- 🚨 reset back to `base=>typescript=>react`
- 🚨 refactor to `extends` for eslint
- 🚨 includes `**/**`

**Before**
```sh
▲ packages [main] yarn lint --force
...
...
...
 Tasks:    13 successful, 13 total
Cached:    0 cached, 13 total
  Time:    4m28.309s 
```

**After**

```sh
▲ packages [refactor/eslint-ts-only] yarn lint --force
...
...
...
 Tasks:    13 successful, 13 total
Cached:    0 cached, 13 total
  Time:    1m53.539s 
```