### PR TITLE
🚑️  (notion) rollupdata return flat (![0]) 😈 [b]

### DIFF
--- a/packages/notion/src/utils/getTypes/rollup.ts
+++ b/packages/notion/src/utils/getTypes/rollup.ts
@@ -25,7 +25,7 @@ const rollup = (data: any) => {
         })
       )
     )
-  )[0]
+  ).flat()
 }
 
 export default rollup


### PR DESCRIPTION
6️⃣ 😈 6️⃣  😈 6️⃣ 