### PR TITLE
🩹  (design-system) VisuallyHidden [b]

### DIFF
--- a/examples/design-system/src/pages/about.tsx
+++ b/examples/design-system/src/pages/about.tsx
@@ -7,6 +7,7 @@ import {
   PageHeading,
   Separator,
   Text,
+  VisuallyHidden,
 } from '@jeromefitz/design-system/src/components'
 import NextLink from 'next/link'
 
@@ -17,6 +18,9 @@ function Home({}) {
         title="About"
         description="Sample page for menu routing testing."
       />
+      <VisuallyHidden>
+        <Text>Not visible.</Text>
+      </VisuallyHidden>
       <Separator decorative my="4" size="full" />
       <Icon.Pencil />
       <Icon.GitHub css={{ color: '$colors$brand' }} />

--- a/packages/design-system/src/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/design-system/src/components/VisuallyHidden/VisuallyHidden.tsx
@@ -1,0 +1,10 @@
+/**
+ * https://www.radix-ui.com/docs/primitives/utilities/visually-hidden
+ */
+import * as ReactVisuallyHidden from '@radix-ui/react-visually-hidden'
+
+const VisuallyHidden = ({ children, ...props }) => (
+  <ReactVisuallyHidden.Root {...props}>{children}</ReactVisuallyHidden.Root>
+)
+
+export { VisuallyHidden }

--- a/packages/design-system/src/components/VisuallyHidden/index.ts
+++ b/packages/design-system/src/components/VisuallyHidden/index.ts
@@ -1,0 +1,1 @@
+export { VisuallyHidden } from './VisuallyHidden'

--- a/packages/design-system/src/components/index.ts
+++ b/packages/design-system/src/components/index.ts
@@ -203,3 +203,4 @@ export {
 export { Tooltip } from './Tooltip'
 export { TreeItem } from './TreeItem'
 export { VerifiedBadge } from './VerifiedBadge'
+export { VisuallyHidden } from './VisuallyHidden'


### PR DESCRIPTION
Cleaning up any `@radix-ui/...` in websites, that is not `colors|icons`