### PR TITLE
👷  (gh-actions) deprecate set-output [b]

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -113,7 +113,7 @@ jobs:
       - name: '📛  Commit Message'
         id: pull-commit-message
         run: |
-          echo "::set-output name=message::$(git log --no-merges -1 --oneline)"
+          echo "message=$(git log --no-merges -1 --oneline)" >> $GITHUB_OUTPUT
 
       - name: '🏗️  Build'
         id: pull-build

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -71,7 +71,7 @@ jobs:
       - name: '📛  Commit Message'
         id: push-commit-message
         run: |
-          echo "::set-output name=message::$(git log --no-merges -1 --oneline)"
+          echo "message=$(git log --no-merges -1 --oneline)" >> $GITHUB_OUTPUT
 
       - name: '🏗️  Build'
         id: push-build


### PR DESCRIPTION
Ref: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/