### PR TITLE
👷  (pnpm) swap to npm install pnpnm [b]

### DIFF
--- a/.github/actions/init/action.yml
+++ b/.github/actions/init/action.yml
@@ -18,9 +18,11 @@ runs:
   steps:
     - name: '🔧  pnpm'
       id: pnpm-setup
-      uses: pnpm/action-setup@v2.4.0
-      with:
-        version: ${{ inputs.pnpm-version }}
+      shell: bash
+      run: npm install -g pnpm@${{ inputs.pnpm-version }}
+      # uses: pnpm/action-setup@v2.4.0
+      # with:
+      #   version: ${{ inputs.pnpm-version }}
 
     - name: '💽️  Node ${{ inputs.node-version }}'
       id: node-setup


### PR DESCRIPTION
`pnpm/actions-setup` does not look to be getting the `node20` treatment

This is a workaround that may just become the fix.