### PR TITLE
🐛 NICE-70 fix gitmoji rewrite; dep-up for release notes [b]

### DIFF
--- a/packages/ccommit/release.config.js
+++ b/packages/ccommit/release.config.js
@@ -18,7 +18,7 @@ const { name } = pkg
 
 const branches = [
   ...configDefault.branches,
-  { name: 'refactor/NICE-123', prerelease: 'canary' },
+  { name: 'NICE-70', prerelease: 'canary' },
 ]
 
 const configPassed = {

--- a/packages/ccommit/src/data/types.ts
+++ b/packages/ccommit/src/data/types.ts
@@ -165,7 +165,7 @@ const types = [
   },
   {
     code: ':package:',
-    description: 'Add or Update Compiled Files or Packages',
+    description: 'Add or update compiled files or packages',
     emoji: '📦️',
     emojiLength: 1,
     semver: SEMVER.PATCH,

--- a/packages/conventional-gitmoji/release.config.js
+++ b/packages/conventional-gitmoji/release.config.js
@@ -16,8 +16,14 @@ const pkg = require('./package.json')
 
 const { name } = pkg
 
+const branches = [
+  ...configDefault.branches,
+  { name: 'NICE-70', prerelease: 'canary' },
+]
+
 const configPassed = {
   ...configDefault,
+  branches,
   tagFormat: `${name}@\${version}`,
 }
 

--- a/packages/conventional-gitmoji/src/config/rewrites.ts
+++ b/packages/conventional-gitmoji/src/config/rewrites.ts
@@ -69,7 +69,7 @@ const rewrites: RewritesProps[] = [
   { from: 'seedling', to: 'seed' },
   { from: 'triangular-flag-on-post', to: 'flags' },
   { from: 'goal-net', to: 'catch' },
-  { from: 'animation', to: 'animation' },
+  { from: 'dizzy', to: 'animation' },
   { from: 'wastebasket', to: 'clean' },
   { from: 'passport-control', to: 'roles' },
   { from: 'adhesive-bandage', to: 'patch' },

--- a/packages/conventional-gitmoji/src/types/releaseRule.ts
+++ b/packages/conventional-gitmoji/src/types/releaseRule.ts
@@ -209,7 +209,7 @@ const releaseRule: IReleaseRule = {
     emoji: '📦️',
     entity: '&#1F4E6;',
     name: 'package',
-    semver: null,
+    semver: 'patch',
   },
   deploy: {
     branch: null,

--- a/packages/release-notes-generator/release.config.js
+++ b/packages/release-notes-generator/release.config.js
@@ -16,8 +16,14 @@ const pkg = require('./package.json')
 
 const { name } = pkg
 
+const branches = [
+  ...configDefault.branches,
+  { name: 'NICE-70', prerelease: 'canary' },
+]
+
 const configPassed = {
   ...configDefault,
+  branches,
   tagFormat: `${name}@\${version}`,
 }
 

--- a/packages/release-notes-generator/src/templates/index.ts
+++ b/packages/release-notes-generator/src/templates/index.ts
@@ -1,4 +1,4 @@
-export { commit } from './commit'
-export { contributor } from './contributor'
-export { footer } from './footer'
-export { header } from './header'
+export { commit } from './commit.js'
+export { contributor } from './contributor.js'
+export { footer } from './footer.js'
+export { header } from './header.js'

--- a/packages/release-notes-generator/src/utils/getMarkdown.ts
+++ b/packages/release-notes-generator/src/utils/getMarkdown.ts
@@ -1,4 +1,4 @@
-import { commit, contributor, footer, header } from '../templates/index'
+import { commit, contributor, footer, header } from '../templates/index.js'
 
 const getMarkdown = async (context, commits) => {
   const {


### PR DESCRIPTION
- [x] 📦️  NICE-70 update `dep-up` to patch [skip ci]
- [x] ♻️  (esm) NICE-70 add missing `.js` [skip ci]
- [x] 🐛  NICE-70 dizzy to animation rewrite [b]


Closes #744