### PR TITLE
🩹  (eslint) NICE-80 `@/**` request internalPattern [b]

### DIFF
--- a/config/eslint-config/src/base.cjs
+++ b/config/eslint-config/src/base.cjs
@@ -68,6 +68,7 @@ const baseConfig = {
           'unknown',
         ],
         'internal-pattern': [
+          '@/**',
           '~**/**',
           // '@/components/**',
           // '@/stores/**',


### PR DESCRIPTION
Keep `~/**` until next breaking, but move to more industry standard localization.