### PR TITLE
✨  (eslint) NICE-129 continued flat config upgrade

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -26,5 +26,4 @@ runs:
         TURBO_TEAM: ${{ inputs.TURBO_TEAM }}
       run: |
         pnpm run ${{ inputs.BUILD_COMMAND }} \
-          --cache-dir=".cache-turbo" \
-          --output-logs="errors-only"
+          --cache-dir=".cache-turbo"

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -22,8 +22,7 @@ runs:
         TURBO_TOKEN: ${{ inputs.TURBO_TOKEN }}
       run: |
         pnpm run lint \
-          --cache-dir=".cache-turbo" \
-          --output-logs="errors-only"
+          --cache-dir=".cache-turbo"
 
     # - name: '🧪️  Test'
     #   id: test

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,15 +31,14 @@
         "eslint-config-turbo",
         "eslint-plugin-turbo"
       ],
-      "groupName": "eslint-config 📏 ",
-      "groupSlug": "eslint-config",
+      "groupName": "lint 📏 ",
+      "groupSlug": "lint",
       "matchPackageNames": [
         "@babel/eslint-parser",
-        "@typescript-eslint/eslint-plugin",
         "@typescript-eslint/parser",
         "prettier"
       ],
-      "matchPackagePatterns": ["^eslint"]
+      "matchPackagePatterns": ["^@eslint", "^eslint"]
     },
     {
       "commitMessagePrefix": "⬆️  (deps)",

--- a/config/eslint-config/README.md
+++ b/config/eslint-config/README.md
@@ -3,68 +3,98 @@
 Custom `eslint-config` setup that can be extended and incorporates:
 
 - `@babel/eslint-parser`
-- `@typescript-eslint/eslint-plugin`
+- `@eslint/*`
 - `@typescript-eslint/parser`
 - `eslint`
 - `eslint-config-next`
 - `eslint-config-prettier`
-- `eslint-plugin-import`
+- `eslint-plugin-import-x`
 - `eslint-plugin-jest`
 - `eslint-plugin-jsx-a11y`
 - `eslint-plugin-react`
 - `eslint-plugin-react-hooks`
 - `prettier`
+- `typescript-eslint`
 
 ## Breakdown
 
-All currently `cjs` format:
-
 - `./index` (base)
 - `./typescript`
-  - `./react` (+ typescript)
-    - `./jest` (+ react)
-    - `./next` (+ react)
+- `./react` (+ typescript)
+  - `./jest` (+ react)
+  - `./next` (+ react)
+    - `./tailwind` (+ next)
 
 ```sh
-yarn add @jeromefitz/eslint-config --dev
+pnpm add @jeromefitz/eslint-config --save-dev
 ```
 
 ### Base
 
-```js
-{
-    "extends": "@jeromefitz/eslint-config"
-}
+```ts
+import { configBase } from '@jeromefitz/eslint-config/base.js'
+
+// ...
+
+const config = [...configBase]
 ```
 
 ### Jest
 
 ```js
-{
-    "extends": "@jeromefitz/eslint-config/jest"
-}
+import { configJest } from '@jeromefitz/eslint-config/jest.js'
+
+// ...
+
+const config = [...configJest]
 ```
 
 ### Next
 
 ```js
-{
-    "extends": "@jeromefitz/eslint-config/next"
-}
+import { configNext } from '@jeromefitz/eslint-config/next.js'
+
+// ...
+
+const config = [...configNext]
 ```
 
 ### React
 
 ```js
-{
-    "extends": "@jeromefitz/eslint-config/react"
-}
+import { configReact } from '@jeromefitz/eslint-config/react.js'
+
+// ...
+
+const config = [...configReact]
 ```
 
-### TypeScript
+### Tailwind
 
 ```js
-{
-    "extends": "@jeromefitz/eslint-config/typescript"
-}
+import { configTailwind } from '@jeromefitz/eslint-config/tailwind.js'
+
+// ...
+
+const config = [...configTailwind]
 ```
+
+### Typescript
+
+```js
+import { configTypescript } from '@jeromefitz/eslint-config/typescript.js'
+
+// ...
+
+const config = [...configTypescript]
+```
+
+## Please Note
+
+The eslint ecosystem will slowly (but surely) move from `eslint@8` to `eslint@9`.
+
+`@jeromefitz/eslint-config@4` will be a holding pattern and may from time-to-time introduce potential **breaking** changes in linting. This is done so we do not have to bump a major _every_ single time we upgrade package(s) from `eslint@8` => `eslint@9`.
+
+In some regards this should be permanent `canary` until then, but will try to call out any breaking in PRs as we move forward.
+
+> **📝 Note:** See #1511 for more information.

--- a/config/eslint-config/package.json
+++ b/config/eslint-config/package.json
@@ -30,14 +30,15 @@
   "dependencies": {
     "@babel/core": "7.24.7",
     "@babel/eslint-parser": "7.24.7",
+    "@eslint/compat": "1.1.0",
     "@eslint/eslintrc": "3.1.0",
+    "@eslint/js": "9.6.0",
     "@next/eslint-plugin-next": "14.2.4",
-    "@typescript-eslint/eslint-plugin": "7.15.0",
     "@typescript-eslint/parser": "7.15.0",
     "eslint": "9.6.0",
     "eslint-config-next": "14.2.4",
     "eslint-config-turbo": "2.0.6",
-    "eslint-plugin-import": "2.29.1",
+    "eslint-plugin-import-x": "0.5.3",
     "eslint-plugin-jest": "28.6.0",
     "eslint-plugin-jest-dom": "5.4.0",
     "eslint-plugin-jsx-a11y": "6.9.0",
@@ -48,12 +49,15 @@
     "eslint-plugin-storybook": "0.8.0",
     "eslint-plugin-tailwindcss": "3.17.4",
     "eslint-plugin-testing-library": "6.2.2",
-    "eslint-plugin-turbo": "2.0.6"
+    "eslint-plugin-turbo": "2.0.6",
+    "typescript-eslint": "7.15.0"
   },
   "devDependencies": {
+    "@types/eslint__js": "8.42.3",
     "@types/lodash": "4.17.6",
     "lodash": "4.17.21",
-    "tailwindcss": "3.4.4"
+    "tailwindcss": "3.4.4",
+    "typescript": "5.5.2"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"

--- a/config/eslint-config/release.config.js
+++ b/config/eslint-config/release.config.js
@@ -18,8 +18,7 @@ const { name } = pkg
 
 const branches = [
   ...configDefault.branches,
-  { name: 'refactor/turbo-2--migration', prerelease: 'canary' },
-  { name: 'NICE-68', prerelease: 'canary' },
+  { name: 'NICE-129', prerelease: 'canary' },
 ]
 
 const configPassed = {

--- a/config/eslint-config/src/base.js
+++ b/config/eslint-config/src/base.js
@@ -1,4 +1,5 @@
 import parserBabel from '@babel/eslint-parser'
+import eslint from '@eslint/js'
 import pluginPerfectionist from 'eslint-plugin-perfectionist'
 
 import { RULES } from './_lib.js'
@@ -7,6 +8,7 @@ const PERFECTIONIST_CONFIG = 'recommended-natural'
 const perfectionistRules = pluginPerfectionist.configs[PERFECTIONIST_CONFIG].rules
 
 const configBase = [
+  eslint.configs.recommended,
   {
     ignores: [
       '.next/*',

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
       "@semantic-release/commit-analyzer@13.0.0": "patches/@semantic-release__commit-analyzer@13.0.0.patch"
     },
     "overrides": {
+      "@typescript-eslint/parser": "7.15.0",
       "micromatch": "4.0.5"
     }
   }

--- a/packages/ccommit/src/commands/commit/commit.ts
+++ b/packages/ccommit/src/commands/commit/commit.ts
@@ -17,6 +17,8 @@ import withHook from './withHook.js'
 
 const { prompt } = enquirer
 
+// @todo(NICE-129) eslint
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type CommitOptions = {
   message?: string
   // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents, @typescript-eslint/no-duplicate-type-constituents
@@ -43,6 +45,9 @@ const promptAndCommit = async (options: CommitOptions) => {
       process.exit(2)
     }
   } else {
+    // @todo(NICE-129) eslint
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     await prompt(questions)
       .then((answers: any) => {
         answers.type = findBy(answers.gitmoji, FIND_BY.EMOJI, FIND_BY.TYPE)
@@ -54,6 +59,8 @@ const promptAndCommit = async (options: CommitOptions) => {
       .catch(console.error)
   }
 
+  // @todo(NICE-129) eslint
+  // eslint-disable-next-line no-extra-boolean-cast
   data.subject = !!data ? formatCommitSubject(options, data) : ''
 
   if (options.mode === COMMIT_MODES.HOOK) {

--- a/packages/ccommit/src/commands/commit/questions.ts
+++ b/packages/ccommit/src/commands/commit/questions.ts
@@ -142,6 +142,8 @@ const questions = [
       // @ts-ignore
       return this.state.initial ? `… tab to use initial value` : ''
     },
+    // @todo(NICE-129) eslint
+    // eslint-disable-next-line no-extra-boolean-cast
     initial: !!getIssueTracker() ? `${getIssueTracker()} ` : '',
     message: 'Please enter the commit title',
     name: 'title',

--- a/packages/conventional-gitmoji/src/changelog/utils/transformer.ts
+++ b/packages/conventional-gitmoji/src/changelog/utils/transformer.ts
@@ -21,6 +21,8 @@ const transformer = (commit: any, context: any) => {
       if (type === null) return
       return (
         // @hack(semantic) strip colon from :type: for stricter comparison
+        // @todo(NICE-129) eslint
+        // eslint-disable-next-line no-useless-escape
         type.replace(/\:/g, '') === c.replace(/\:/g, '') ||
         type === t ||
         type === v ||

--- a/packages/conventional-gitmoji/src/config/rewrites.ts
+++ b/packages/conventional-gitmoji/src/config/rewrites.ts
@@ -2,6 +2,8 @@
  * @note pseudo-map to conventional-commits
  */
 
+// @todo(NICE-129) eslint
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type RewritesProps = {
   branch?: null | string
   from: string

--- a/packages/conventional-gitmoji/src/types/releaseRule.types.ts
+++ b/packages/conventional-gitmoji/src/types/releaseRule.types.ts
@@ -1,5 +1,7 @@
 import type { ICommit } from './commit.types.js'
 
+// @todo(NICE-129) eslint
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type IReleaseRuleProps = {
   branch: null | string
   code: string

--- a/packages/conventional-gitmoji/src/utils/getGitmojiConventional.ts
+++ b/packages/conventional-gitmoji/src/utils/getGitmojiConventional.ts
@@ -15,6 +15,8 @@ const getGitmoji = (): IReleaseRule => {
   // eslint-disable-next-line complexity
   gitmojis.map((gitmoji: any) => {
     const rewrite = _rewrites.find((r) => r?.from === gitmoji.name)
+    // @todo(NICE-129) eslint
+    // eslint-disable-next-line no-extra-boolean-cast
     if (!!rewrite) {
       const semver =
         rewrite.semver === undefined
@@ -22,6 +24,8 @@ const getGitmoji = (): IReleaseRule => {
           : rewrite.semver || gitmoji?.semver || null
 
       _types[rewrite.to] = {
+        // @todo(NICE-129) eslint
+        // eslint-disable-next-line no-extra-boolean-cast
         branch: Boolean(rewrite?.branch) ? rewrite.branch : null,
         code: gitmoji?.code,
         commit: rewrite.to,
@@ -37,6 +41,8 @@ const getGitmoji = (): IReleaseRule => {
          *
          * ["major","premajor","minor","preminor","patch","prepatch","prerelease"]
          **/
+        // @todo(NICE-129) eslint
+        // eslint-disable-next-line no-extra-boolean-cast
         semver: !!semver
           ? semver
               .replace('fix', 'patch')

--- a/packages/conventional-gitmoji/src/utils/getReleaseRules.ts
+++ b/packages/conventional-gitmoji/src/utils/getReleaseRules.ts
@@ -5,6 +5,8 @@ import type { IReleaseRule, IReleaseRuleProps } from '../index.js'
 // const splitter = new GraphemeSplitter()
 
 // @note(semantic-release) can we re-use types here?
+// @todo(NICE-129) eslint
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type CustomReleaseRulesProps = {
   message?: null | string
   release?: null | string

--- a/packages/notion/src/index.ts
+++ b/packages/notion/src/index.ts
@@ -15,11 +15,15 @@ import {
   getQuery,
 } from './queries/index.js'
 
+// @todo(NICE-129) eslint
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type CredentialProps = {
   auth: string
   config: any
 }
 
+// @todo(NICE-129) eslint
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type CustomProps = {
   getBlocksByIdChildren: any
   getDatabasesByIdQuery: any
@@ -30,6 +34,8 @@ type CustomProps = {
   getQuery: any
 }
 
+// @todo(NICE-129) eslint
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type DataTypesProps = {
   LISTING: any
   LISTING_BY_DATE: any
@@ -37,6 +43,8 @@ type DataTypesProps = {
   SLUG_BY_ROUTE: any
 }
 
+// @todo(NICE-129) eslint
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type ClientProps = {
   custom: CustomProps
   dataTypes: DataTypesProps

--- a/packages/notion/src/queries/getDeepFetchAllChildren/index.ts
+++ b/packages/notion/src/queries/getDeepFetchAllChildren/index.ts
@@ -1,7 +1,8 @@
 const getDeepFetchAllChildren = async ({
   blocks,
   getBlocksChildrenList,
-  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+  // @todo(NICE-129) eslint
+  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents, @typescript-eslint/array-type
 }): Promise<Array<any | any[]>> => {
   if (blocks === null || blocks === undefined) return blocks
   const fetchChildrenMap = blocks

--- a/packages/notion/src/queries/getInfoType/index.ts
+++ b/packages/notion/src/queries/getInfoType/index.ts
@@ -13,6 +13,8 @@ const getInfoType = ({ config, item, meta, routeType }) => {
       date = item.properties[
         NOTION[routeType.toUpperCase()].infoType.key
       ]?.start.slice(0, 10)
+      // @todo(NICE-129) eslint
+      // eslint-disable-next-line no-case-declarations, no-unsafe-optional-chaining
       const [year, month, day] = date?.split('-')
       as = `/${routeType}/${year}/${month}/${day}/${slug}`
       break

--- a/packages/notion/src/queries/getNotionListingByDate/index.ts
+++ b/packages/notion/src/queries/getNotionListingByDate/index.ts
@@ -1,3 +1,5 @@
+// @todo(NICE-129) eslint
+/* eslint-disable no-extra-boolean-cast */
 import { sortObject } from '@jeromefitz/utils'
 
 import _map from 'lodash/map.js'

--- a/packages/notion/src/queries/getNotionSlugByRoute/index.ts
+++ b/packages/notion/src/queries/getNotionSlugByRoute/index.ts
@@ -1,3 +1,5 @@
+// @todo(NICE-129) eslint
+/* eslint-disable no-extra-boolean-cast */
 import { sortObject } from '@jeromefitz/utils'
 
 import _omit from 'lodash/omit.js'

--- a/packages/notion/src/queries/getQuery/index.ts
+++ b/packages/notion/src/queries/getQuery/index.ts
@@ -57,6 +57,8 @@ const getQuery = async ({ config, notionDatabasesQuery, reqQuery }) => {
     // @todo(types)
     const filterTagEpisodesByPodcasts: any = []
     const podcastIds: any = []
+    // @todo(NICE-129) eslint
+    // eslint-disable-next-line no-unsafe-optional-chaining
     !!podcasts && podcastIds.push(...podcasts?.split(','))
     _size(podcastIds) > 0 &&
       _map(podcastIds, (id) =>
@@ -88,6 +90,8 @@ const getQuery = async ({ config, notionDatabasesQuery, reqQuery }) => {
     await avoidRateLimit(0)
     // @todo(types) any
     let contentData: Pick<any, number | string | symbol>
+    // @todo(NICE-129) eslint
+    // eslint-disable-next-line no-extra-boolean-cast
     if (!!filter) {
       // @hack(notion)-do-not-return'
       if (filter?.or.length === 0) {

--- a/packages/notion/src/utils/dataNormalized/index.ts
+++ b/packages/notion/src/utils/dataNormalized/index.ts
@@ -1,3 +1,5 @@
+// @todo(NICE-129) eslint
+/* eslint-disable no-extra-boolean-cast */
 import _map from 'lodash/map.js'
 
 import { LOOKUP, PROPERTIES_LOOKUP } from '../../constants/index.js'

--- a/packages/notion/src/utils/getTitle/index.ts
+++ b/packages/notion/src/utils/getTitle/index.ts
@@ -6,6 +6,8 @@ import _last from 'lodash/last.js'
  */
 const getTitle = (title: string) => {
   const _title: string = _last(title.split('_')) ?? ''
+  // @todo(NICE-129) eslint
+  // eslint-disable-next-line no-extra-boolean-cast
   if (!!_title) {
     return _title
       .replace('Past', 'Cast Emeritus')

--- a/packages/notion/src/utils/getTypes/rich_text.ts
+++ b/packages/notion/src/utils/getTypes/rich_text.ts
@@ -1,4 +1,6 @@
 const rich_text = (data: any) =>
+  // @todo(NICE-129) eslint
+  // eslint-disable-next-line no-extra-boolean-cast
   !!data?.rich_text ? data?.rich_text[0]?.plain_text : null
 
 export default rich_text

--- a/packages/notion/src/utils/getTypes/rollup.ts
+++ b/packages/notion/src/utils/getTypes/rollup.ts
@@ -8,6 +8,8 @@ import getTypes from '../../utils/getTypes/index.js'
 /**
  * @note(notion) https://github.com/JeromeFitz/packages/issues/631
  */
+// @todo(NICE-129) eslint
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type Rollup = {
   array: any
   function: RollupFunction

--- a/packages/notion/src/utils/getTypes/select.ts
+++ b/packages/notion/src/utils/getTypes/select.ts
@@ -6,6 +6,8 @@ const select = (data: any) => {
   const s: any = data.select
   // console.dir(`getTypeSelectNormalized`)
   // console.dir(data)
+  // @todo(NICE-129) eslint
+  // eslint-disable-next-line no-extra-boolean-cast
   if (!!s) {
     s.slug = slugger.slug(data.select.name)
     return { [s.id]: s }

--- a/packages/notion/src/utils/getTypes/title.ts
+++ b/packages/notion/src/utils/getTypes/title.ts
@@ -1,3 +1,5 @@
+// @todo(NICE-129) eslint
+// eslint-disable-next-line no-extra-boolean-cast
 const title = (data: any) => (!!data?.title ? data?.title[0]?.plain_text : null)
 
 export default title

--- a/packages/release-notes-generator/src/templates/commit.ts
+++ b/packages/release-notes-generator/src/templates/commit.ts
@@ -26,6 +26,8 @@ const commit = (context, commits, meta) => {
       // markdownReferenceArray.push(
       //   `[ ${reference.issue} ](${repositoryUrl}/${reference.issue})`
       // )
+      // @todo(NICE-129) eslint
+      // eslint-disable-next-line no-extra-boolean-cast
       if (!!reference.issue) {
         markdownReferenceArray.push(`[ #${reference.issue} ]`)
       }

--- a/packages/release-notes-generator/src/templates/contributor.ts
+++ b/packages/release-notes-generator/src/templates/contributor.ts
@@ -72,6 +72,8 @@ const contributor = async (context, commits, meta) => {
         })
         .then(({ data }) => {
           const login = data.items[0]?.login
+          // @todo(NICE-129) eslint
+          // eslint-disable-next-line no-extra-boolean-cast
           if (!!login) {
             authors[authorIdx]['login'] = login
             return login

--- a/packages/release-notes-generator/src/utils/processCommit.ts
+++ b/packages/release-notes-generator/src/utils/processCommit.ts
@@ -12,6 +12,8 @@ function processCommit(chunk, transform, context) {
 
   try {
     chunk = JSON.parse(chunk)
+    // @todo(NICE-129) eslint
+    // eslint-disable-next-line no-empty
   } catch (e) {}
 
   commit = _cloneDeep(chunk)

--- a/packages/semantic/src/plugins/git.ts
+++ b/packages/semantic/src/plugins/git.ts
@@ -17,6 +17,8 @@ const git = (options: GitPluginOptions): PluginSpec => {
         typeof options.gitAssets === 'boolean'
           ? false
           : ['package.json']
+              // @todo(NICE-129) eslint
+              // eslint-disable-next-line no-extra-boolean-cast
               .concat(!!options.gitAssets ? options.gitAssets : [])
               .filter((a) => a),
       message: options.message

--- a/packages/spotify/src/index.ts
+++ b/packages/spotify/src/index.ts
@@ -46,12 +46,16 @@ interface NowPlayingProps {
   withImages?: boolean
 }
 
+// @todo(NICE-129) eslint
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type GetProps = {
   nowPlaying({ withImages }: NowPlayingProps): any
   topArtists({ limit, offset, time_range, withImages }: QueryProps): any
   topTracks({ limit, offset, time_range, withImages }: QueryProps): any
 }
 
+// @todo(NICE-129) eslint
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type ClientProps = {
   get: GetProps
 }
@@ -93,6 +97,8 @@ class Client {
   #fetch: any
   #prefixUrl: string
   #refreshToken: string
+  // @todo(NICE-129) eslint
+  // eslint-disable-next-line no-unused-private-class-members
   #spotifyVersion: string
 
   #userAgent: string
@@ -356,6 +362,8 @@ class Client {
       headers['content-type'] = 'application/json'
     }
 
+    // @todo(NICE-129) eslint
+    // eslint-disable-next-line no-useless-catch
     try {
       // @todo(timeout)
       const response = await this.#fetch(url.toString(), {

--- a/packages/utils/src/omit/index.ts
+++ b/packages/utils/src/omit/index.ts
@@ -1,3 +1,5 @@
+// @todo(NICE-129) eslint
+// eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
 const omit = (obj: { [x: string]: any }, props: any[]) => {
   obj = { ...obj }
   props.forEach((prop: number | string) => delete obj[prop])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@typescript-eslint/parser': 7.15.0
   micromatch: 4.0.5
 
 patchedDependencies:
@@ -85,15 +86,18 @@ importers:
       '@babel/eslint-parser':
         specifier: 7.24.7
         version: 7.24.7(@babel/core@7.24.7)(eslint@9.6.0)
+      '@eslint/compat':
+        specifier: 1.1.0
+        version: 1.1.0
       '@eslint/eslintrc':
         specifier: 3.1.0
         version: 3.1.0
+      '@eslint/js':
+        specifier: 9.6.0
+        version: 9.6.0
       '@next/eslint-plugin-next':
         specifier: 14.2.4
         version: 14.2.4
-      '@typescript-eslint/eslint-plugin':
-        specifier: 7.15.0
-        version: 7.15.0(@typescript-eslint/parser@7.15.0(eslint@9.6.0)(typescript@5.5.2))(eslint@9.6.0)(typescript@5.5.2)
       '@typescript-eslint/parser':
         specifier: 7.15.0
         version: 7.15.0(eslint@9.6.0)(typescript@5.5.2)
@@ -106,12 +110,12 @@ importers:
       eslint-config-turbo:
         specifier: 2.0.6
         version: 2.0.6(eslint@9.6.0)
-      eslint-plugin-import:
-        specifier: 2.29.1
-        version: 2.29.1(@typescript-eslint/parser@7.15.0(eslint@9.6.0)(typescript@5.5.2))(eslint@9.6.0)
+      eslint-plugin-import-x:
+        specifier: 0.5.3
+        version: 0.5.3(eslint@9.6.0)(typescript@5.5.2)
       eslint-plugin-jest:
         specifier: 28.6.0
-        version: 28.6.0(@typescript-eslint/eslint-plugin@7.15.0(@typescript-eslint/parser@7.15.0(eslint@9.6.0)(typescript@5.5.2))(eslint@9.6.0)(typescript@5.5.2))(eslint@9.6.0)(typescript@5.5.2)
+        version: 28.6.0(eslint@9.6.0)(typescript@5.5.2)
       eslint-plugin-jest-dom:
         specifier: 5.4.0
         version: 5.4.0(eslint@9.6.0)
@@ -123,7 +127,7 @@ importers:
         version: 2.11.0(eslint@9.6.0)(typescript@5.5.2)
       eslint-plugin-playwright:
         specifier: 1.6.2
-        version: 1.6.2(eslint-plugin-jest@28.6.0(@typescript-eslint/eslint-plugin@7.15.0(@typescript-eslint/parser@7.15.0(eslint@9.6.0)(typescript@5.5.2))(eslint@9.6.0)(typescript@5.5.2))(eslint@9.6.0)(typescript@5.5.2))(eslint@9.6.0)
+        version: 1.6.2(eslint-plugin-jest@28.6.0(eslint@9.6.0)(typescript@5.5.2))(eslint@9.6.0)
       eslint-plugin-react:
         specifier: 7.34.3
         version: 7.34.3(eslint@9.6.0)
@@ -142,7 +146,13 @@ importers:
       eslint-plugin-turbo:
         specifier: 2.0.6
         version: 2.0.6(eslint@9.6.0)
+      typescript-eslint:
+        specifier: 7.15.0
+        version: 7.15.0(eslint@9.6.0)(typescript@5.5.2)
     devDependencies:
+      '@types/eslint__js':
+        specifier: 8.42.3
+        version: 8.42.3
       '@types/lodash':
         specifier: 4.17.6
         version: 4.17.6
@@ -152,6 +162,9 @@ importers:
       tailwindcss:
         specifier: 3.4.4
         version: 3.4.4
+      typescript:
+        specifier: 5.5.2
+        version: 5.5.2
 
   config/lint-staged:
     dependencies:
@@ -664,6 +677,10 @@ packages:
     resolution: {integrity: sha512-Zm2NGpWELsQAD1xsJzGQpYfvICSsFkEpU0jxBjfdC6uNEWXcHnfs9hScFWtXVDVl+rBQJGrl4g1vcKIejpH9dA==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
+  '@eslint/compat@1.1.0':
+    resolution: {integrity: sha512-s9Wi/p25+KbzxKlDm3VshQdImhWk+cbdblhwGNnyCU5lpSwtWa4v7VQCxSki0FAUrGA3s8nCWgYzAH41mwQVKQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/config-array@0.17.0':
     resolution: {integrity: sha512-A68TBu6/1mHHuc5YJL0U0VVeGNiklLAL6rRmhTCP2B5XjWLMnrX+HkO+IAXyHvks5cyyY1jjK5ITPQ1HGS2EVA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -961,6 +978,12 @@ packages:
   '@storybook/csf@0.0.1':
     resolution: {integrity: sha512-USTLkZze5gkel8MYCujSRBVIrUQ3YPBrLOx7GNk/0wttvVtlzWXAq9eLbQ4p/NicGxP+3T7KPEMVV//g+yubpw==}
 
+  '@types/eslint@8.56.10':
+    resolution: {integrity: sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==}
+
+  '@types/eslint__js@8.42.3':
+    resolution: {integrity: sha512-alfG737uhmPdnvkrLdZLcEKJ/B8s9Y4hrZ+YAdzUeoArBlSUERA2E87ROfOaS4jd/C45fzOoZzidLc1IPwLqOw==}
+
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
 
@@ -995,7 +1018,7 @@ packages:
     resolution: {integrity: sha512-uiNHpyjZtFrLwLDpHnzaDlP3Tt6sGMqTCiqmxaN4n4RP0EfYZDODJyddiFDF44Hjwxr5xAcaYxVKm9QKQFJFLA==}
     engines: {node: ^18.18.0 || >=20.0.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^7.0.0
+      '@typescript-eslint/parser': 7.15.0
       eslint: ^8.56.0
       typescript: '*'
     peerDependenciesMeta:
@@ -1005,16 +1028,6 @@ packages:
   '@typescript-eslint/parser@7.15.0':
     resolution: {integrity: sha512-k9fYuQNnypLFcqORNClRykkGOMOj+pV6V91R4GO/l1FDGwpqmSwoOQrOHo3cGaH63e+D3ZiCAOsuS/D2c99j/A==}
     engines: {node: ^18.18.0 || >=20.0.0}
-    peerDependencies:
-      eslint: ^8.56.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@typescript-eslint/parser@7.2.0':
-    resolution: {integrity: sha512-5FKsVcHTk6TafQKQbuIVkXq58Fnbkd2wDL4LB7AURN7RUOu1utVP+G8+6u3ZhEroW3DF6hyo3ZEXxgKgp4KeCg==}
-    engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       eslint: ^8.56.0
       typescript: '*'
@@ -1037,10 +1050,6 @@ packages:
   '@typescript-eslint/scope-manager@7.15.0':
     resolution: {integrity: sha512-Q/1yrF/XbxOTvttNVPihxh1b9fxamjEoz2Os/Pe38OHwxC24CyCqXxGTOdpb4lt6HYtqw9HetA/Rf6gDGaMPlw==}
     engines: {node: ^18.18.0 || >=20.0.0}
-
-  '@typescript-eslint/scope-manager@7.2.0':
-    resolution: {integrity: sha512-Qh976RbQM/fYtjx9hs4XkayYujB/aPwglw2choHmf3zBjB4qOywWSdt9+KLRdHubGcoSwBnXUH2sR3hkyaERRg==}
-    engines: {node: ^16.0.0 || >=18.0.0}
 
   '@typescript-eslint/type-utils@7.15.0':
     resolution: {integrity: sha512-SkgriaeV6PDvpA6253PDVep0qCqgbO1IOBiycjnXsszNTVQe5flN5wR5jiczoEoDEnAqYFSFFc9al9BSGVltkg==}
@@ -1067,10 +1076,6 @@ packages:
   '@typescript-eslint/types@7.15.0':
     resolution: {integrity: sha512-aV1+B1+ySXbQH0pLK0rx66I3IkiZNidYobyfn0WFsdGhSXw+P3YOqeTq5GED458SfB24tg+ux3S+9g118hjlTw==}
     engines: {node: ^18.18.0 || >=20.0.0}
-
-  '@typescript-eslint/types@7.2.0':
-    resolution: {integrity: sha512-XFtUHPI/abFhm4cbCDc5Ykc8npOKBSJePY3a3s+lwumt7XWJuzP5cZcfZ610MIPHjQjNsOLlYK8ASPaNG8UiyA==}
-    engines: {node: ^16.0.0 || >=18.0.0}
 
   '@typescript-eslint/typescript-estree@5.62.0':
     resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
@@ -1102,15 +1107,6 @@ packages:
   '@typescript-eslint/typescript-estree@7.15.0':
     resolution: {integrity: sha512-gjyB/rHAopL/XxfmYThQbXbzRMGhZzGw6KpcMbfe8Q3nNQKStpxnUKeXb0KiN/fFDR42Z43szs6rY7eHk0zdGQ==}
     engines: {node: ^18.18.0 || >=20.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@typescript-eslint/typescript-estree@7.2.0':
-    resolution: {integrity: sha512-cyxS5WQQCoBwSakpMrvMXuMDEbhOo9bNHHrNcEWis6XHx6KF518tkF1wBvKIn/tpq5ZpUYK7Bdklu8qY0MsFIA==}
-    engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -1156,10 +1152,6 @@ packages:
   '@typescript-eslint/visitor-keys@7.15.0':
     resolution: {integrity: sha512-Hqgy/ETgpt2L5xueA/zHHIl4fJI2O4XUE9l4+OIfbJIRSnTJb/QscncdqqZzofQegIJugRIF57OJea1khw2SDw==}
     engines: {node: ^18.18.0 || >=20.0.0}
-
-  '@typescript-eslint/visitor-keys@7.2.0':
-    resolution: {integrity: sha512-c6EIQRHhcpl6+tO8EMR+kjkkV+ugUNXOmeASA1rlzkd8EPIriavpWoiEz1HR/VLhbVIdhqnV6E7JZm00cBDx2A==}
-    engines: {node: ^16.0.0 || >=18.0.0}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1671,6 +1663,10 @@ packages:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
 
+  doctrine@3.0.0:
+    resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
+    engines: {node: '>=6.0.0'}
+
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
     engines: {node: '>=8'}
@@ -1849,6 +1845,12 @@ packages:
         optional: true
       eslint-import-resolver-webpack:
         optional: true
+
+  eslint-plugin-import-x@0.5.3:
+    resolution: {integrity: sha512-hJ/wkMcsLQXAZL3+txXIDpbW5cqwdm1rLTqV4VRY03aIbzE3zWE7rPZKW6Gzf7xyl1u3V1iYC6tOG77d9NF4GQ==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      eslint: ^8.56.0 || ^9.0.0-0
 
   eslint-plugin-import@2.29.1:
     resolution: {integrity: sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==}
@@ -2832,10 +2834,6 @@ packages:
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
-  minimatch@9.0.3:
-    resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
   minimatch@9.0.4:
     resolution: {integrity: sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -3669,6 +3667,9 @@ packages:
   split2@1.0.0:
     resolution: {integrity: sha512-NKywug4u4pX/AZBB1FCPzZ6/7O+Xhz1qMVbzTvvKvikjO99oPN87SkK08mEY9P63/5lWjK+wgOOgApnTg5r6qg==}
 
+  stable-hash@0.0.4:
+    resolution: {integrity: sha512-LjdcbuBeLcdETCrPn9i8AYAZ1eCtu4ECAWtP7UleOiZ9LzVxRzzUZEoZ8zB24nhkQnDWyET0I+3sWokSDS3E7g==}
+
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
     engines: {node: '>=18'}
@@ -3903,6 +3904,9 @@ packages:
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
+  tslib@2.6.3:
+    resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
+
   tsup@8.1.0:
     resolution: {integrity: sha512-UFdfCAXukax+U6KzeTNO2kAARHcWxmKsnvSPXUcfA1D+kU05XDccCrkffCQpFaWDsZfV0jMyTsxU39VfCp6EOg==}
     engines: {node: '>=18'}
@@ -4004,6 +4008,16 @@ packages:
   typedarray.prototype.slice@1.0.3:
     resolution: {integrity: sha512-8WbVAQAUlENo1q3c3zZYuy5k9VzBQvp8AX9WOtbvyWlLM1v5JaSRmjubLjzHF4JFtptjH/5c/i95yaElvcjC0A==}
     engines: {node: '>= 0.4'}
+
+  typescript-eslint@7.15.0:
+    resolution: {integrity: sha512-Ta40FhMXBCwHura4X4fncaCVkVcnJ9jnOq5+Lp4lN8F4DzHZtOwZdRvVBiNUGznUDHPwdGnrnwxmUOU2fFQqFA==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      eslint: ^8.56.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   typescript@5.5.2:
     resolution: {integrity: sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==}
@@ -4459,6 +4473,8 @@ snapshots:
 
   '@eslint-community/regexpp@4.10.1': {}
 
+  '@eslint/compat@1.1.0': {}
+
   '@eslint/config-array@0.17.0':
     dependencies:
       '@eslint/object-schema': 2.1.4
@@ -4801,6 +4817,15 @@ snapshots:
     dependencies:
       lodash: 4.17.21
 
+  '@types/eslint@8.56.10':
+    dependencies:
+      '@types/estree': 1.0.5
+      '@types/json-schema': 7.0.15
+
+  '@types/eslint__js@8.42.3':
+    dependencies:
+      '@types/eslint': 8.56.10
+
   '@types/estree@1.0.5': {}
 
   '@types/is-ci@3.0.4':
@@ -4859,19 +4884,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.2.0(eslint@9.6.0)(typescript@5.5.2)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 7.2.0
-      '@typescript-eslint/types': 7.2.0
-      '@typescript-eslint/typescript-estree': 7.2.0(typescript@5.5.2)
-      '@typescript-eslint/visitor-keys': 7.2.0
-      debug: 4.3.5
-      eslint: 9.6.0
-    optionalDependencies:
-      typescript: 5.5.2
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/scope-manager@5.62.0':
     dependencies:
       '@typescript-eslint/types': 5.62.0
@@ -4892,11 +4904,6 @@ snapshots:
       '@typescript-eslint/types': 7.15.0
       '@typescript-eslint/visitor-keys': 7.15.0
 
-  '@typescript-eslint/scope-manager@7.2.0':
-    dependencies:
-      '@typescript-eslint/types': 7.2.0
-      '@typescript-eslint/visitor-keys': 7.2.0
-
   '@typescript-eslint/type-utils@7.15.0(eslint@9.6.0)(typescript@5.5.2)':
     dependencies:
       '@typescript-eslint/typescript-estree': 7.15.0(typescript@5.5.2)
@@ -4916,8 +4923,6 @@ snapshots:
   '@typescript-eslint/types@7.13.1': {}
 
   '@typescript-eslint/types@7.15.0': {}
-
-  '@typescript-eslint/types@7.2.0': {}
 
   '@typescript-eslint/typescript-estree@5.62.0(typescript@5.5.2)':
     dependencies:
@@ -4971,21 +4976,6 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.4
-      semver: 7.6.2
-      ts-api-utils: 1.3.0(typescript@5.5.2)
-    optionalDependencies:
-      typescript: 5.5.2
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/typescript-estree@7.2.0(typescript@5.5.2)':
-    dependencies:
-      '@typescript-eslint/types': 7.2.0
-      '@typescript-eslint/visitor-keys': 7.2.0
-      debug: 4.3.5
-      globby: 11.1.0
-      is-glob: 4.0.3
-      minimatch: 9.0.3
       semver: 7.6.2
       ts-api-utils: 1.3.0(typescript@5.5.2)
     optionalDependencies:
@@ -5059,11 +5049,6 @@ snapshots:
   '@typescript-eslint/visitor-keys@7.15.0':
     dependencies:
       '@typescript-eslint/types': 7.15.0
-      eslint-visitor-keys: 3.4.3
-
-  '@typescript-eslint/visitor-keys@7.2.0':
-    dependencies:
-      '@typescript-eslint/types': 7.2.0
       eslint-visitor-keys: 3.4.3
 
   acorn-jsx@5.3.2(acorn@8.11.3):
@@ -5617,6 +5602,10 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  doctrine@3.0.0:
+    dependencies:
+      esutils: 2.0.3
+
   dot-prop@5.3.0:
     dependencies:
       is-obj: 2.0.0
@@ -5810,11 +5799,11 @@ snapshots:
     dependencies:
       '@next/eslint-plugin-next': 14.2.4
       '@rushstack/eslint-patch': 1.10.3
-      '@typescript-eslint/parser': 7.2.0(eslint@9.6.0)(typescript@5.5.2)
+      '@typescript-eslint/parser': 7.15.0(eslint@9.6.0)(typescript@5.5.2)
       eslint: 9.6.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@9.6.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.6.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@9.6.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@9.6.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.15.0(eslint@9.6.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.6.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.15.0(eslint@9.6.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@9.6.0)
       eslint-plugin-jsx-a11y: 6.9.0(eslint@9.6.0)
       eslint-plugin-react: 7.34.3(eslint@9.6.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@9.6.0)
@@ -5837,13 +5826,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@9.6.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.6.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.15.0(eslint@9.6.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.6.0):
     dependencies:
       debug: 4.3.5
       enhanced-resolve: 5.17.0
       eslint: 9.6.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.2.0(eslint@9.6.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@9.6.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.6.0))(eslint@9.6.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.2.0(eslint@9.6.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@9.6.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.15.0(eslint@9.6.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.15.0(eslint@9.6.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.6.0))(eslint@9.6.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.15.0(eslint@9.6.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@9.6.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-core-module: 2.14.0
@@ -5854,39 +5843,46 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.15.0(eslint@9.6.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint@9.6.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.15.0(eslint@9.6.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.15.0(eslint@9.6.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.6.0))(eslint@9.6.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.15.0(eslint@9.6.0)(typescript@5.5.2)
       eslint: 9.6.0
       eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.15.0(eslint@9.6.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.6.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.2.0(eslint@9.6.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@9.6.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.6.0))(eslint@9.6.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.15.0(eslint@9.6.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.15.0(eslint@9.6.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.6.0))(eslint@9.6.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 7.2.0(eslint@9.6.0)(typescript@5.5.2)
+      '@typescript-eslint/parser': 7.15.0(eslint@9.6.0)(typescript@5.5.2)
       eslint: 9.6.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@9.6.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.6.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.15.0(eslint@9.6.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.6.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.2.0(eslint@9.6.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@9.6.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.6.0))(eslint@9.6.0):
+  eslint-plugin-import-x@0.5.3(eslint@9.6.0)(typescript@5.5.2):
     dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 7.2.0(eslint@9.6.0)(typescript@5.5.2)
+      '@typescript-eslint/utils': 7.15.0(eslint@9.6.0)(typescript@5.5.2)
+      debug: 4.3.5
+      doctrine: 3.0.0
       eslint: 9.6.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.2.0(eslint@9.6.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.6.0)
+      get-tsconfig: 4.7.5
+      is-glob: 4.0.3
+      minimatch: 9.0.4
+      semver: 7.6.2
+      stable-hash: 0.0.4
+      tslib: 2.6.3
     transitivePeerDependencies:
       - supports-color
+      - typescript
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.15.0(eslint@9.6.0)(typescript@5.5.2))(eslint@9.6.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.15.0(eslint@9.6.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@9.6.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
@@ -5896,7 +5892,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.6.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.15.0(eslint@9.6.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint@9.6.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.15.0(eslint@9.6.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.15.0(eslint@9.6.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.6.0))(eslint@9.6.0)
       hasown: 2.0.2
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -5908,33 +5904,6 @@ snapshots:
       tsconfig-paths: 3.15.0
     optionalDependencies:
       '@typescript-eslint/parser': 7.15.0(eslint@9.6.0)(typescript@5.5.2)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.2.0(eslint@9.6.0)(typescript@5.5.2))(eslint-import-resolver-typescript@3.6.1)(eslint@9.6.0):
-    dependencies:
-      array-includes: 3.1.7
-      array.prototype.findlastindex: 1.2.3
-      array.prototype.flat: 1.3.2
-      array.prototype.flatmap: 1.3.2
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 9.6.0
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.2.0(eslint@9.6.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.2.0(eslint@9.6.0)(typescript@5.5.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.6.0))(eslint@9.6.0)
-      hasown: 2.0.2
-      is-core-module: 2.13.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.7
-      object.groupby: 1.0.1
-      object.values: 1.1.7
-      semver: 6.3.1
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 7.2.0(eslint@9.6.0)(typescript@5.5.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -5946,12 +5915,10 @@ snapshots:
       eslint: 9.6.0
       requireindex: 1.2.0
 
-  eslint-plugin-jest@28.6.0(@typescript-eslint/eslint-plugin@7.15.0(@typescript-eslint/parser@7.15.0(eslint@9.6.0)(typescript@5.5.2))(eslint@9.6.0)(typescript@5.5.2))(eslint@9.6.0)(typescript@5.5.2):
+  eslint-plugin-jest@28.6.0(eslint@9.6.0)(typescript@5.5.2):
     dependencies:
       '@typescript-eslint/utils': 7.11.0(eslint@9.6.0)(typescript@5.5.2)
       eslint: 9.6.0
-    optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 7.15.0(@typescript-eslint/parser@7.15.0(eslint@9.6.0)(typescript@5.5.2))(eslint@9.6.0)(typescript@5.5.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -5986,12 +5953,12 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-playwright@1.6.2(eslint-plugin-jest@28.6.0(@typescript-eslint/eslint-plugin@7.15.0(@typescript-eslint/parser@7.15.0(eslint@9.6.0)(typescript@5.5.2))(eslint@9.6.0)(typescript@5.5.2))(eslint@9.6.0)(typescript@5.5.2))(eslint@9.6.0):
+  eslint-plugin-playwright@1.6.2(eslint-plugin-jest@28.6.0(eslint@9.6.0)(typescript@5.5.2))(eslint@9.6.0):
     dependencies:
       eslint: 9.6.0
       globals: 13.24.0
     optionalDependencies:
-      eslint-plugin-jest: 28.6.0(@typescript-eslint/eslint-plugin@7.15.0(@typescript-eslint/parser@7.15.0(eslint@9.6.0)(typescript@5.5.2))(eslint@9.6.0)(typescript@5.5.2))(eslint@9.6.0)(typescript@5.5.2)
+      eslint-plugin-jest: 28.6.0(eslint@9.6.0)(typescript@5.5.2)
 
   eslint-plugin-react-hooks@4.6.2(eslint@9.6.0):
     dependencies:
@@ -6943,10 +6910,6 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.11
 
-  minimatch@9.0.3:
-    dependencies:
-      brace-expansion: 2.0.1
-
   minimatch@9.0.4:
     dependencies:
       brace-expansion: 2.0.1
@@ -7729,6 +7692,8 @@ snapshots:
     dependencies:
       through2: 2.0.5
 
+  stable-hash@0.0.4: {}
+
   stdin-discarder@0.2.2: {}
 
   stop-iteration-iterator@1.0.0:
@@ -8034,6 +7999,8 @@ snapshots:
 
   tslib@1.14.1: {}
 
+  tslib@2.6.3: {}
+
   tsup@8.1.0(typescript@5.5.2):
     dependencies:
       bundle-require: 4.0.2(esbuild@0.21.4)
@@ -8144,6 +8111,17 @@ snapshots:
       es-errors: 1.3.0
       typed-array-buffer: 1.0.2
       typed-array-byte-offset: 1.0.2
+
+  typescript-eslint@7.15.0(eslint@9.6.0)(typescript@5.5.2):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 7.15.0(@typescript-eslint/parser@7.15.0(eslint@9.6.0)(typescript@5.5.2))(eslint@9.6.0)(typescript@5.5.2)
+      '@typescript-eslint/parser': 7.15.0(eslint@9.6.0)(typescript@5.5.2)
+      '@typescript-eslint/utils': 7.15.0(eslint@9.6.0)(typescript@5.5.2)
+      eslint: 9.6.0
+    optionalDependencies:
+      typescript: 5.5.2
+    transitivePeerDependencies:
+      - supports-color
 
   typescript@5.5.2: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "noImplicitAny": false,
-    "noEmit": true,
+    "noEmit": true
   },
   "extends": "@jeromefitz/tsconfig/src/node20.json",
-  "exclude": [],
+  "exclude": []
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
@@ -10,6 +11,7 @@
         "*.mjs",
         "package.json"
       ],
+      "outputLogs": "new-only",
       "outputs": ["dist/**", ".next/**"]
     },
     "clean": {
@@ -30,7 +32,8 @@
         "*.js",
         "*.mjs",
         "package.json"
-      ]
+      ],
+      "outputLogs": "new-only"
     },
     "format:lint": {
       "cache": false,
@@ -46,22 +49,26 @@
     },
     "test": {
       "dependsOn": ["lint", "build"],
+      "outputLogs": "new-only",
       "outputs": ["coverage/**"]
     },
     "@jeromefitz/notion#build": {
       "dependsOn": ["@jeromefitz/utils#build"],
-      "inputs": ["src/**", "*.cjs", "*.js", "*.mjs", "package.json"]
+      "inputs": ["src/**", "*.cjs", "*.js", "*.mjs", "package.json"],
+      "outputLogs": "new-only"
     },
     "@jeromefitz/semantic#build": {
       "dependsOn": [
         "@jeromefitz/conventional-gitmoji#build",
         "@jeromefitz/release-notes-generator#build"
       ],
-      "inputs": ["src/**", "*.cjs", "*.js", "*.mjs", "package.json"]
+      "inputs": ["src/**", "*.cjs", "*.js", "*.mjs", "package.json"],
+      "outputLogs": "new-only"
     },
     "@jeromefitz/spotify#build": {
       "dependsOn": ["@jeromefitz/utils#build"],
-      "inputs": ["src/**", "*.cjs", "*.js", "*.mjs", "package.json"]
+      "inputs": ["src/**", "*.cjs", "*.js", "*.mjs", "package.json"],
+      "outputLogs": "new-only"
     }
   },
   "ui": "stream"


### PR DESCRIPTION
### typescript-eslint

Continue migration to `eslint@9`

#### New Rules

This has the potential to be a **b/r/e/a/k/i/n/g change**, reason being there seems to be some new rules due to moving packages. Specifically around:

- `@typescript-eslint/consistent-type-definitions`: Use an `interface` instead of a `type`  
- `no-extra-boolean-cast`: Redundant double negation
- `no-empty-pattern`: Unexpected empty object pattern

These all should probably be fixed but will be `ignored` for now and addressed later.

Applications _importing_ this package will need to do the same. At the risk of bumping a major _every_ single time we upgrade package(s) from `eslint@8` => `eslint@9` we are going to use `@jeromefitz/eslint-conifg@4` as a holding pattern.

- [x] Updated README with above

#### Packages

##### Add

- [x] `@types/eslint__js`
- [x] `@eslint/compat`
- [x] `@eslint/js`
- [x] `eslint-plugin-import-x` (migrated from `eslint-plugin-import`)
- [x] `typescript-eslint`

##### Remove

- [x] `eslint-plugin-import` (migrated to `eslint-plugin-import-x`)
- [x] `typescript-eslint/eslint-plugin`

**Please Note:** This is continual as the eslint ecosystem continues to slowly (but surely) move to `eslint@9`. There are some hacks currently to be able to account for config|plugin that are `@8`. They will continue to be removed / updated.

#### Refactor

Needed to add back some rules that have gone away from recommended plugins/configs.

### Apply Formatting

- [x] Add `@todo(NICE-129)` to identify that we _should_ update these, but should not within this PR

### Configuration

- [x] Override `@typescript-eslint/parser@7.15.0`
- [x] Renovate: eslint rework
- [x] Turbo: Move to `outputLogs: "new-only"` (away from `errors-only`) 

Closes #1507 