### PR TITLE
💥  (eslint) NICE-130 swap to ongoing canary|next [skip ci]

### DIFF
--- a/config/eslint-config/release.config.js
+++ b/config/eslint-config/release.config.js
@@ -17,8 +17,9 @@ const pkg = require('./package.json')
 const { name } = pkg
 
 const branches = [
-  ...configDefault.branches,
-  { name: 'NICE-129', prerelease: 'canary' },
+  { name: 'main', prerelease: 'canary' },
+  { name: 'canary' },
+  { name: 'NICE-130', prerelease: 'next' },
 ]
 
 const configPassed = {


### PR DESCRIPTION
At the risk of bumping a major every single time we upgrade package(s) from `eslint@8 => eslint@9` we are going to use:

- `main` => `@jeromefitz/eslint-conifg@5.0.0-canary`
- `NICE-XYZ` => `@jeromefitz/eslint-conifg@5.0.0-next`

This way we can take our time as the eslint ecosystem takes theirs, and continue to use prereleases that can have more breaking changes without holding everything up. ➕

BREAKING CHANGE: Move to 5.0.0-canary to track ongoing eslint 9 migration